### PR TITLE
6 modify reusable publish pypi workflow to use pypi upload

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -5,7 +5,10 @@ on:
         required: false
         type: string
         default: "3.x"
-
+    secrets:
+      pypi-pw:
+        description: "SHR_PYPI_CICD_UPLOAD_PWD stored in secrets manager"
+        required: true
 jobs:
   create_package:
     name: Package
@@ -55,4 +58,3 @@ jobs:
       - name: Copy Compiled file
         run: |
           twine upload --repository-url https://pypi.shr.myome.info/simple -u ${PYPI_USER} -p ${PYPI_PW} *
-          

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -38,21 +38,21 @@ jobs:
     runs-on: ubuntu-latest
     needs: [create_package]
     env:
-      # Organization secrets are stored in 
-      # https://github.com/organizations/myome/settings/secrets/actions
-      # and originally in 
-      # https://us-east-2.console.aws.amazon.com/secretsmanager/home?region=us-east-2#!/secret?name=pypi%2Fci_aws_keys
-      AWS_ACCESS_KEY_ID: ${{ secrets.PYPI_AWS_ACCESS_KEY_ID }}
-      AWS_SECRET_ACCESS_KEY: ${{ secrets.PYPI_AWS_SECRET_ACCESS_KEY }}
+      PYPI_USER: github_cicd_uploader
+      PYPI_PW: ${{ secrets.pypi-pw }}
     steps:
       - uses: actions/download-artifact@v2
         with:
           name: dist
-      - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v1
+      - name: Set up Python
+        uses: actions/setup-python@v2
         with:
-          aws-region: us-east-2
+          python-version: '3.x'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install twine
       - name: Copy Compiled file
         run: |
-          aws s3 cp *.whl s3://myome-pypi/packages/myome-djangobase/
-          aws s3 cp *.tar.gz s3://myome-pypi/packages/myome-djangobase/
+          twine upload --repository-url https://pypi.shr.myome.info/simple -u ${PYPI_USER} -p ${PYPI_PW} *
+          

--- a/README.md
+++ b/README.md
@@ -39,40 +39,43 @@ jobs:
 
 ## Python  
 ### bandit: *code security checks*
-&emsp;inputs:
-  - **src:** source directory (defaults to ".")
-  - **options:** bandit flags (defaults to "-r")
-  - **py-version:** version of python to use (defaults to "3.x")
+&emsp;**Inputs**  
+&emsp;`src`: source directory (defaults to ".")  
+&emsp;`options`: bandit flags (defaults to "-r")  
+&emsp;`py-version`: version of python to use (defaults to "3.x")  
 
 ### black: *code formatting*
-&emsp;inputs:
-  - **src:** source directory (defaults to ".")
-  - **options:** black flags
-  - **py-version:** version of python to use (defaults to "3.x")
+&emsp;**Inputs**  
+&emsp;`src`: source directory (defaults to ".")  
+&emsp;`options`: black flags  
+&emsp;`py-version`: version of python to use (defaults to "3.x")  
 
-### flake8: *style guide enforcement*
-&emsp;inputs:
-  - **src:** source directory (defaults to ".")
-  - **options:** flake8 flags
+### flake8: *style guide enforcement*  
+&emsp;**Inputs**  
+&emsp;`src`: source directory (defaults to ".")  
+&emsp;`options`: flake8 flags  
 
 ### mypy: *static type checking*
-&emsp;inputs:
-  - **src:** source directory (defaults to ".")
-  - **options:** mypy flags (defaults to "-v")
+&emsp;**Inputs**  
+&emsp;`src`: source directory (defaults to ".")  
+&emsp;`options`: mypy flags (defaults to "-v")  
 
-### publish: *push packages to pypi*
-&emsp;inputs:
-  - **py-version:** version of python to use (defaults to "3.x")
+### publish: *upload packages to Myome SHR pypi*
+&emsp;**Inputs**   
+&emsp;`py-version`: version of python to use (defaults to "3.x")  
+
+&emsp;**Secrets**   
+&emsp;`pypi-pw`: SHR_PYPI_CICD_UPLOAD_PWD stored as Github secret  
 
 ### pylint: *static code analysis*
-&emsp;inputs:
-  - **src:** source directory (defaults to ".")
-  - **options:** pylint flags
+&emsp;**Inputs**  
+&emsp;`src`: source directory (defaults to ".")  
+&emsp;`options`: pylint flags  
 
 ### pytest: *test code runner*
-&emsp;inputs:
-  - **src:** source directory (defaults to ".")
-  - **options:** pytest flags (defaults to "-v")
+&emsp;**Inputs**  
+&emsp;`src`: source directory (defaults to ".")  
+&emsp;`options`: pytest flags (defaults to "-v")  
 
 <br/>
 


### PR DESCRIPTION
Implements a reusable workflow for uploading packages to https://pypi.shr.myome.info/ using an upload user. 

Please use this across all of our python repos. Tested and working with [myome-controller package](https://github.com/myome/myome-controller) 

Example use: https://github.com/myome/myome-controller/blob/main/.github/workflows/publish.yml

Closes #6 