### PR TITLE
Update build-and-push-to-shr-ecr.yml

### DIFF
--- a/.github/workflows/build-and-push-to-shr-ecr.yml
+++ b/.github/workflows/build-and-push-to-shr-ecr.yml
@@ -30,8 +30,8 @@ jobs:
     steps:
     - name: Check out code
       uses: actions/checkout@v2
-      with:
-        submodules: true
+    - name: Check out submodules 
+      run: git submodule update --init
 
     - name: Configure AWS credentials
       uses: aws-actions/configure-aws-credentials@v1


### PR DESCRIPTION
@ScottCruzen0 I am hitting a permission issue with submodule checkout (see https://github.com/myome/df_prs_scoring/actions/runs/3968116573/jobs/6800874140) as if credentials used for the main repo are not accessible when checking out submodules. Trying running direct command instead. Please let me know if you have a better fix for this.